### PR TITLE
fixed a flaky test org.openapitools.codegen.DefaultCodegenTest.testVa…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3948,7 +3948,9 @@ public class DefaultCodegen implements CodegenConfig {
             property.example = "ERROR_TO_EXAMPLE_VALUE";
         }
 
-        property.jsonSchema = Json.pretty(p);
+        // here p is of type Schema. When this is converted to string, the order of elements is changing. Solution is to use tree Map
+        // The Json.mapper() is inserting the values from p in random order into the datastructure we mention, hence I decided to use TreeMap instead of LinkedHashMap
+        property.jsonSchema = Json.pretty(Json.mapper().convertValue(p, TreeMap.class));
 
         if (p.getDeprecated() != null) {
             property.deprecated = p.getDeprecated();


### PR DESCRIPTION
In the file DefaultCodegen.java under modules/openapi-generator/src/main/java/org/openapitools/codegen , The class schema object is being converted to string using 
Json.pretty(p);  where p is the object of class Schema

Due to internal serialization of custom types, the string returned has different order making it flaky.

To fix this and keep the uniformity, I have made the following change
Json.pretty(Json.mapper().convertValue(p, TreeMap.class));

this is ensuring that the output is consistent.
