### PR TITLE
fixed flaky test org.openapitools.codegen.java.JavaClientCodegenTest.…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -133,7 +133,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     protected String serializationLibrary = null;
     protected boolean useOneOfDiscriminatorLookup = false; // use oneOf discriminator's mapping for model lookup
     protected String rootJavaEEPackage;
-    protected Map<String, MpRestClientVersion> mpRestClientVersions = new HashMap<>();
+    protected Map<String, MpRestClientVersion> mpRestClientVersions = new LinkedHashMap<>();
     protected boolean useSingleRequestParameter = false;
     protected boolean webclientBlockingOperations = false;
     protected boolean generateClientAsBean = false;


### PR DESCRIPTION
Fixed flaky test `testMicroprofileRestClientIncorrectVersion` in `org.openapitools.codegen.java.JavaClientCodegenTest`

The following command was used to detect flakiness using [nondex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn  -pl modules/openapi-generator edu.illinois:nondex-maven-plugin:2.1.1:nondex  -Dtest=org.openapitools.codegen.java.JavaClientCodegenTest#testMicroprofileRestClientIncorrectVersion
```

Non-Dex detected flakiness in the **_message given_** when this test throws an exception. More precisely as shown below:

> The exception was thrown with the wrong message: expected "Version incorrectVersion of MicroProfile Rest Client is not supported or incorrect. Supported versions are 1.4.1, 2.0, 3.0" but got "Version incorrectVersion of MicroProfile Rest Client is not supported or incorrect. Supported versions are 2.0, 3.0, 1.4.1"

**Explanation:**

This is because we have hard defined an expected message string in the test as shown:

https://github.com/Suraj-Vashista-BK/openapi-generator/blob/a1d00e4785f6ecd3a9a4fa981a8215948a75e8d4/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java#L1704-L1709

This exception string is built in the file `JavaClientCodegen.java` in `org.openapitools.codegen.languages`
and while we are building the exception string, we use a hashmap called `mpRestClientVersions` to do so as shown below:

https://github.com/Suraj-Vashista-BK/openapi-generator/blob/a1d00e4785f6ecd3a9a4fa981a8215948a75e8d4/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java#L364-L369

The main reason for flakiness is `mpRestClientVersions.keySet()` because a map's keySet function returns a Set and the set's iterator method says in its [documentation](https://docs.oracle.com/javase/8/docs/api/java/util/Set.html#iterator--) that the elements are returned in no particular order (unless this set is an instance of some class that provides a guarantee). This introduces non determinism in the output of the keySet resulting in flakiness in the generated string.

**Proposed Fix:**

To address this issue and maintain the order , I have converted `mpRestClientVersions` from **_HashMap_** to **_linkedHashMap_** during its declaration:

https://github.com/Suraj-Vashista-BK/openapi-generator/blob/08418c89d9de3a379cd254655c5f702c04c05796/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java#L136

This ensures that we get the versions in the expected order. After this fix, nondex did not detect any flakiness.

**Test Environment:**

> openjdk version "11.0.20.1"
> Apache Maven 3.6.3
> Ubuntu 20.04.6 LTS
> Linux version 5.4.0-156-generic
